### PR TITLE
Add customizable lists of iconified commands.

### DIFF
--- a/README.org
+++ b/README.org
@@ -34,15 +34,15 @@
 
 * Customization
 
-  By default ~all-the-icons-ivy-setup~ iconifies only some commands, you can customize it by setting variables ~all-the-icons-ivy-buffer-cmds~ and ~all-the-icons-ivy-file-cmds~ before calling.
+  By default ~all-the-icons-ivy-setup~ iconifies only some commands, you can customize it by setting variables ~all-the-icons-ivy-buffer-commands~ and ~all-the-icons-ivy-file-commands~ before calling.
   E.g. if you don't want to add icons to buffer names:
   #+BEGIN_SRC elisp
-    (setq all-the-icons-ivy-buffer-cmds '())
+    (setq all-the-icons-ivy-buffer-commands '())
   #+END_SRC
 
   or to iconify more file commands
   #+BEGIN_SRC elisp
-    (setq all-the-icons-ivy-file-cmds
+    (setq all-the-icons-ivy-file-commands
           '(counsel-find-file counsel-file-jump counsel-recentf counsel-projectile-find-file counsel-projectile-find-dir))
   #+END_SRC
 

--- a/README.org
+++ b/README.org
@@ -15,6 +15,14 @@
    (all-the-icons-ivy-setup)
    #+END_SRC
 
+   or using [[https://github.com/jwiegley/use-package][Use-package]]:
+
+   #+BEGIN_SRC elisp
+     (use-package all-the-icons-ivy
+       :config
+       (all-the-icons-ivy-setup))
+   #+END_SRC
+
 ** Manual
 
    Clone this repo and:
@@ -23,6 +31,21 @@
    (add-to-load-path "/path/to/repo")
    (all-the-icons-ivy-setup)
    #+END_SRC
+
+* Customization
+
+  By default ~all-the-icons-ivy-setup~ iconifies only some commands, you can customize it by setting variables ~all-the-icons-ivy-buffer-cmds~ and ~all-the-icons-ivy-file-cmds~ before calling.
+  E.g. if you don't want to add icons to buffer names:
+  #+BEGIN_SRC elisp
+    (setq all-the-icons-ivy-buffer-cmds '())
+  #+END_SRC
+
+  or to iconify more file commands
+  #+BEGIN_SRC elisp
+    (setq all-the-icons-ivy-file-cmds
+          '(counsel-find-file counsel-file-jump counsel-recentf counsel-projectile-find-file counsel-projectile-find-dir))
+  #+END_SRC
+
 
 * Contribution
 

--- a/all-the-icons-ivy.el
+++ b/all-the-icons-ivy.el
@@ -40,14 +40,14 @@
   "Shows icons while using ivy and counsel."
   :group 'ivy)
 
-(defcustom all-the-icons-ivy-buffer-cmds
+(defcustom all-the-icons-ivy-buffer-commands
   '(ivy-switch-buffer ivy-switch-buffer-other-window counsel-projectile-switch-to-buffer)
   "Commands to use with `all-the-icons-ivy-buffer-transformer'."
   :type '(repeat function)
   :group 'all-the-icons-ivy)
 
 
-(defcustom all-the-icons-ivy-file-cmds
+(defcustom all-the-icons-ivy-file-commands
   '(counsel-find-file counsel-projectile-find-file counsel-projectile-find-dir)
   "Commands to use with `all-the-icons-ivy-file-transformer'."
   :type '(repeat function)
@@ -96,9 +96,9 @@ falls back to `ivy-recentf' and the same transformer is used."
 ;;;###autoload
 (defun all-the-icons-ivy-setup ()
   "Set ivy's display transformers to show relevant icons next to the candidates."
-  (dolist (cmd all-the-icons-ivy-buffer-cmds)
+  (dolist (cmd all-the-icons-ivy-buffer-commands)
     (ivy-set-display-transformer cmd 'all-the-icons-ivy-buffer-transformer))
-  (dolist (cmd all-the-icons-ivy-file-cmds)
+  (dolist (cmd all-the-icons-ivy-file-commands)
     (ivy-set-display-transformer cmd 'all-the-icons-ivy-file-transformer)))
 
 (provide 'all-the-icons-ivy)

--- a/all-the-icons-ivy.el
+++ b/all-the-icons-ivy.el
@@ -36,6 +36,23 @@
 (require 'all-the-icons)
 (require 'ivy)
 
+(defgroup all-the-icons-ivy nil
+  "Shows icons while using ivy and counsel."
+  :group 'ivy)
+
+(defcustom all-the-icons-ivy-buffer-cmds
+  '(ivy-switch-buffer ivy-switch-buffer-other-window counsel-projectile-switch-to-buffer)
+  "Commands to use with `all-the-icons-ivy-buffer-transformer'."
+  :type '(repeat function)
+  :group 'all-the-icons-ivy)
+
+
+(defcustom all-the-icons-ivy-file-cmds
+  '(counsel-find-file counsel-projectile-find-file counsel-projectile-find-dir)
+  "Commands to use with `all-the-icons-ivy-file-transformer'."
+  :type '(repeat function)
+  :group 'all-the-icons-ivy)
+
 (defun all-the-icons-ivy--buffer-propertize (b s)
   "If buffer B is modified apply `ivy-modified-buffer' face on string S."
   (if (and (buffer-file-name b)
@@ -79,12 +96,10 @@ falls back to `ivy-recentf' and the same transformer is used."
 ;;;###autoload
 (defun all-the-icons-ivy-setup ()
   "Set ivy's display transformers to show relevant icons next to the candidates."
-  (ivy-set-display-transformer 'ivy-switch-buffer                   'all-the-icons-ivy-buffer-transformer)
-  (ivy-set-display-transformer 'ivy-switch-buffer-other-window      'all-the-icons-ivy-buffer-transformer)
-  (ivy-set-display-transformer 'counsel-find-file                   'all-the-icons-ivy-file-transformer)
-  (ivy-set-display-transformer 'counsel-projectile-find-file        'all-the-icons-ivy-file-transformer)
-  (ivy-set-display-transformer 'counsel-projectile-switch-to-buffer 'all-the-icons-ivy-file-transformer)
-  (ivy-set-display-transformer 'counsel-projectile-find-dir         'all-the-icons-ivy-file-transformer))
+  (dolist (cmd all-the-icons-ivy-buffer-cmds)
+    (ivy-set-display-transformer cmd 'all-the-icons-ivy-buffer-transformer))
+  (dolist (cmd all-the-icons-ivy-file-cmds)
+    (ivy-set-display-transformer cmd 'all-the-icons-ivy-file-transformer)))
 
 (provide 'all-the-icons-ivy)
 


### PR DESCRIPTION
Besides all-the-icons-ivy I also use [ivy-rich](https://github.com/Yevgnen/ivy-rich) to add transformers for my counsel/ivy buffer-operation commands. So I decided it would be great to have a possibility to customize which commands should be decorated by all-the-icons-ivy.